### PR TITLE
Zipit Z2 Port: add correct alsa card name for Z2

### DIFF
--- a/Makefile.zipit
+++ b/Makefile.zipit
@@ -1,5 +1,5 @@
-PRGNAME     = sms_sdl
-CC			= /opt/zipit-toolchain/bin/arm-buildroot-linux-musleabi-gcc
+PRGNAME	= sms_sdl
+CC	= /path/to/openwrt-zipit/staging_dir/toolchain-arm_xscale_gcc-5.3.0_musl-1.1.14_eabi/bin/arm-openwrt-linux-gcc
 
 # Possible choices : rs97, k3s (PAP K3S), sdl, amini, fbdev
 PORT = zipit
@@ -26,6 +26,7 @@ CFLAGS		= -Ofast -fsingle-precision-constant -fno-PIC -flto
 CFLAGS		+= -falign-functions=1 -falign-jumps=1 -falign-loops=1 -falign-labels=1
 CFLAGS		+= -DLSB_FIRST -std=gnu99 -DALIGN_DWORD
 CFLAGS		+= -Isource -Isource/cpu_cores/$(Z80_CORE) -Isource/scalers -Isource/ports/$(PORT) -I./source/sound -Isource/unzip -Isource/sdl -Isource/sound/$(SOUND_ENGINE) -Isource/sound_output
+CFLAGS		+= -I/path/to/openwrt-zipit/staging_dir/target-arm_xscale_musl-1.1.14_eabi/usr/include -L/path/to/openwrt-zipit/staging_dir/target-arm_xscale_musl-1.1.14_eabi/usr/lib
 
 SRCDIR		+= ./source/text/fb
 CFLAGS		+= -Isource/text/fb
@@ -50,7 +51,7 @@ CFLAGS		+= -Isource/scale2x
 SRCDIR		+= ./source/scale2x
 endif
 
-LDFLAGS     = -lc -lgcc -lm -lSDL -lasound -no-pie -Wl,--as-needed -Wl,--gc-sections -s -flto
+LDFLAGS     = -lc -lgcc -lm -lSDL -lasound -Wl,--as-needed -Wl,--gc-sections -s -flto
 
 ifeq ($(SOUND_OUTPUT), portaudio)
 LDFLAGS		+= -lportaudio

--- a/source/sound_output/alsa/sound_output_alsa.c
+++ b/source/sound_output/alsa/sound_output_alsa.c
@@ -20,6 +20,11 @@ void Sound_Init(void)
 	/* Open PCM device for playback. */
 	int32_t rc = snd_pcm_open(&handle, "default", SND_PCM_STREAM_PLAYBACK, 0);
 
+#if PORT==zipit
+	if (rc < 0)
+		rc = snd_pcm_open(&handle, "plughw:Z2,0", SND_PCM_STREAM_PLAYBACK, 0);
+#endif
+
 	if (rc < 0)
 		rc = snd_pcm_open(&handle, "plughw:0,0,0", SND_PCM_STREAM_PLAYBACK, 0);
 


### PR DESCRIPTION
This gets alsa sound output working on Zipit Z2. Updated Makefile.zipit so it can be built with the openwrt toolchain after editing the proper paths.