### PR TITLE
Numerous fixes for games, ports etc...

### DIFF
--- a/docs/BROKEN_GAMES_LIST.txt
+++ b/docs/BROKEN_GAMES_LIST.txt
@@ -79,16 +79,6 @@ https://github.com/OpenEmu/CrabEmu-Core/blob/a25c7277cd14f9e32647e1b9e1a45621fb0
 Problematic games (To be checked & tested)
 =================================
 
--   Alibaba and 40 Thieves / Block Hole 
-
-http://www.smspower.org/Development/AlibabaAnd40Thieves-SMS
-Looks like it will need more research.
-
--  California Games II
-
-http://www.smspower.org/Development/CaliforniaGamesII-SMS
-Sonic's Edusoft had a similar issue with it expecting VDP Register 1 to be set to 0xE0, which is what the BIOS sets it to.
-
 -  Dallyeora Pigu Wang
 
 http://www.smspower.org/Development/DallyeoraPiguWang-SMS
@@ -99,15 +89,6 @@ Sounds like a problem.
 -  James Pond 3 - Operation Starfi5h (Game Gear)
 
 http://www.smspower.org/Development/JamesPond3-GG
-
-- Madou Monogatari 2 (Game Gear)
-
-Marat Fayzullin mentionned this in the changelog of his MasterGear emulator.
-"Fixed Madou Monogatari 2 (GG) by setting VDP[6]=0xFF on reset."
-
-This is a very obscure hardware behaviour, i haven't seen this documented anywhere.
-SMS Plus GX works without the fix in place. Saving/loading also works.
-Maybe it's an unrelated issue on his side ?
 
 -  Rainbow Islands
 

--- a/source/loadrom.c
+++ b/source/loadrom.c
@@ -22,7 +22,7 @@
 
 #include "shared.h"
 
-#define GAME_DATABASE_CNT 97
+#define GAME_DATABASE_CNT 99
 
 typedef struct
 {
@@ -169,6 +169,12 @@ static rominfo_t game_list[GAME_DATABASE_CNT] =
 	"Super Kick Off [SMS-GG]"},
 	{0xBD1CC7DF, 0, DEVICE_PAD2B, MAPPER_SEGA, DISPLAY_NTSC, TERRITORY_DOMESTIC, CONSOLE_GGMS,
 	"Super Tetris (KR)"},
+	
+	/* Games requiring uninitialized work RAM due to Japanese BIOS not clearing memory. */
+	{0x08BF3DE3, 0, DEVICE_PAD2B, MAPPER_NONE, DISPLAY_NTSC, TERRITORY_DOMESTIC, CONSOLE_SMS,
+	"Alibaba and 40 Thieves"},
+	{0x643B6B76, 0, DEVICE_PAD2B, MAPPER_NONE, DISPLAY_NTSC, TERRITORY_DOMESTIC, CONSOLE_SMS,
+	"Block Hole"},
 
 	/* Games requiring 3D Glasses */
 	{0xFBF96C81, 1, DEVICE_PAD2B, MAPPER_SEGA, DISPLAY_NTSC, TERRITORY_EXPORT, CONSOLE_SMS2,

--- a/source/ports/fbdev/smsplus.c
+++ b/source/ports/fbdev/smsplus.c
@@ -617,13 +617,13 @@ int main (int argc, char *argv[])
 	option.fullscreen = 1;
 	option.fm = 1;
 	option.spritelimit = 1;
-	option.country = 0;
 	option.tms_pal = 2;
 	option.nosound = 0;
 	option.soundlevel = 2;
 	
 	config_load();
 	
+	option.country = 0;
 	option.console = 0;
 	
 	strcpy(option.game_name, argv[1]);

--- a/source/ports/k3s/smsplus.c
+++ b/source/ports/k3s/smsplus.c
@@ -752,13 +752,13 @@ int main (int argc, char *argv[])
 	option.fullscreen = 1;
 	option.fm = 1;
 	option.spritelimit = 1;
-	option.country = 0;
 	option.tms_pal = 2;
 	option.nosound = 0;
 	option.soundlevel = 2;
 	
 	config_load();
 	
+	option.country = 0;
 	option.console = 0;
 	
 	strcpy(option.game_name, argv[1]);

--- a/source/ports/rs90/smsplus.c
+++ b/source/ports/rs90/smsplus.c
@@ -811,13 +811,13 @@ int main (int argc, char *argv[])
 	option.fullscreen = 1;
 	option.fm = 1;
 	option.spritelimit = 1;
-	option.country = 0;
 	option.tms_pal = 2;
 	option.nosound = 0;
 	option.soundlevel = 2;
 	
 	config_load();
 	
+	option.country = 0;
 	option.console = 0;
 	
 	snprintf(option.game_name, sizeof(option.game_name), "%s", basename(argv[1]));

--- a/source/sms.c
+++ b/source/sms.c
@@ -191,7 +191,18 @@ void sms_reset(void)
   /* clear SMS context */
   memset(dummy_write,data_bus_pullup, sizeof(dummy_write));
   memset(dummy_read,data_bus_pullup, sizeof(dummy_read));
-  memset(sms.wram,0, sizeof(sms.wram));
+  /* The joys of uninitiliazed memory ! The Japanese and Korean BIOS do not properly clear the memory and some games like Alibaba and 40 Thieves relies on this.
+   * Without said fix, Alibaba will flicker (or it seems that it constantly resets ?). See the thread about this behaviour here :
+   * https://www.smspower.org/forums/13333-UninitializedMemoryPatterns */
+  if (sms.territory == TERRITORY_DOMESTIC && sms.console == CONSOLE_SMS)
+  {
+	  memset(sms.wram, 0xF0, sizeof(sms.wram));
+  }
+  else
+  {
+	  memset(sms.wram, 0, sizeof(sms.wram));
+  }
+
   sms.paused    = 0x00;
   sms.save      = 0x00;
   sms.fm_detect = 0x00;

--- a/source/sound/maxim_sn76489/sn76489.c
+++ b/source/sound/maxim_sn76489/sn76489.c
@@ -23,7 +23,7 @@
 #include "shared.h"
 
 #define NoiseInitialState   0x8000  /* Initial state of shift register */
-#define PSG_CUTOFF          0x6     /* Value below which PSG does not output */
+#define PSG_CUTOFF          0x1     /* Value below which PSG does not output */
 
 /* These values are taken from a real SMS2's output */
 static const int32_t PSGVolumeValues[2][16] = 

--- a/source/sound/maxim_sn76489/sn76489.h
+++ b/source/sound/maxim_sn76489/sn76489.h
@@ -2,7 +2,7 @@
 #ifndef SN76489_H_
 #define SN76489_H_
 
-#define MAX_SN76489     4
+#define MAX_SN76489     1
 
 /*
     More testing is needed to find and confirm feedback patterns for

--- a/source/sound/sound.c
+++ b/source/sound/sound.c
@@ -133,6 +133,7 @@ uint32_t SMSPLUS_sound_init(void)
 	/* Set up SN76489 emulation */
 	#ifdef MAXIM_PSG
     SN76489_Init(0, snd.psg_clock, snd.sample_rate);
+    SN76489_Config(0, MUTE_ALLON, BOOST_ON, VOL_FULL, (sms.console < CONSOLE_SMS) ? FB_SC3000 : FB_SEGAVDP);
     #else
 	sn76489_init(&psg_sn, (float)snd.psg_clock, (float)snd.sample_rate, 
 	(sms.console < CONSOLE_SMS) ? SN76489_NOISE_BITS_SG1000 : SN76489_NOISE_BITS_SMS, 


### PR DESCRIPTION
#99a9804 (with #95e823b) fixes an issue with Alibaba and 40 Thieves as well as Block hole requiring uninitialized memory. This thread talks more about it here :
https://www.smspower.org/forums/13333-UninitializedMemoryPatterns
It seems though that it is not exactly 0xF0 for everything so this will have to be tweaked later on.

The standard SDL port also now uses the Retrostone code instead so it is a bit more versatile now, rather than assuming a resolution of 320x240.

There are also sound fixes for SG-1000 & Colecovision games using Maxim's PSG.
The cutoff was also tweaked as it was not exactly right : this sounds closer to what MAME would sound like now.