### PR TITLE
Prevent a potential crash when loading states

### DIFF
--- a/source/state.c
+++ b/source/state.c
@@ -89,6 +89,7 @@ void system_load_state(FILE* fd)
 
     /* Load Z80 context */
     fread(Z80_Context, sizeof(z80_t), sizeof(int8_t), fd);
+    Z80.irq_callback = sms_irq_callback;
 
     /* Load YM2413 context */
     buf = malloc(FM_GetContextSize());


### PR DESCRIPTION
While working on a libretro port, loading states keeps failing. compiling with asan showed me this 
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==79508==ERROR: AddressSanitizer: SEGV on unknown address 0x7f0fc699c250 (pc 0x7f0fc699c250 bp 0x7ffea7f21530 sp 0x7ffea7f214f8 T0)
==79508==The signal is caused by a READ memory access.
AddressSanitizer:DEADLYSIGNAL
AddressSanitizer: nested bug in the same thread, aborting.
```
restoring **Z80.irq_callback = sms_irq_callback** after loading prevents this potential issue.

